### PR TITLE
Fix documentation typo

### DIFF
--- a/doc/source/storage.md
+++ b/doc/source/storage.md
@@ -26,7 +26,7 @@ We have two modes of operation:
 -   `s3` &mdash; Is the real one. It has endless options and endless ways to get
     lost.
 
-The mode is set by the `STORAGE_MODE` environment variable. If it's not set,
+The mode is set by the `STORAGES_MODE` environment variable. If it's not set,
 then we default to `s3`.
 
 ### Common settings


### PR DESCRIPTION
`STORAGE_MODE` is is missing an `S` and should be `STORAGES_MODE`, like in the code