### PR TITLE
Install rest_framework_gis only if postgis is enabled

### DIFF
--- a/src/model_w/preset/django/__init__.py
+++ b/src/model_w/preset/django/__init__.py
@@ -571,7 +571,8 @@ class ModelWDjango(AutoPreset):
         """
 
         yield from self._install_app(context, "rest_framework", 80)
-        yield from self._install_app(context, "rest_framework_gis", 80)
+        if self.enable_postgis:
+            yield from self._install_app(context, "rest_framework_gis", 80)
 
     def post_helper(self, context):
         """


### PR DESCRIPTION
Use the available flag to know if the app `rest_framework_gis` should be installed.