### PR TITLE
fix: add USE_TZ setting

### DIFF
--- a/src/model_w/preset/django/__init__.py
+++ b/src/model_w/preset/django/__init__.py
@@ -376,6 +376,7 @@ class ModelWDjango(AutoPreset):
         yield "USE_I18N", True
         yield "USE_L10N", True
         yield "TIME_ZONE", env.get("TIME_ZONE", self.default_time_zone)
+        yield "USE_TZ", True
 
     def post_languages(self, context):
         """


### PR DESCRIPTION
Add missing `USE_TZ` setting in `ModelWDjango.pre_languages`